### PR TITLE
Add basic starting point for a clang format file based on Googles style

### DIFF
--- a/eCP/.clang-format
+++ b/eCP/.clang-format
@@ -1,0 +1,18 @@
+# See Clang 12 doc: https://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+BasedOnStyle: Google
+
+Language: Cpp
+
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+ColumnLimit: 110
+IndentWidth: 2
+
+BreakBeforeBraces: Stroustrup
+
+NamespaceIndentation: None
+AlignEscapedNewlines: true
+AlignTrailingComments: true


### PR DESCRIPTION
I agree. Couldn't decide on column length. 

**Cons with large column:**
1. Very ugly formatting here and there with too long lines
2. You can't see all code on half a screen

**Cons with small column:**
1. My usually "out of the way to the right" kind-of-comments now need to be removed or moved to the line above


