### PR TITLE
Add swig directive and cmake swig flags

### DIFF
--- a/eCP/swig/CMakeLists.txt
+++ b/eCP/swig/CMakeLists.txt
@@ -5,7 +5,7 @@ include(UseSWIG)
 find_package(PythonLibs)
 include_directories(${PYTHON_INCLUDE_PATH})
 
-set_property(SOURCE eCP.i PROPERTY CPLUSPLUS ON)
+set_property(SOURCE eCP.i PROPERTY CPLUSPLUS ON "-builtin" "-extranative" "-Wall")
 set_property(SOURCE eCP.i PROPERTY SWIG_MODULE_NAME eCP_wrapper)
 
 swig_add_library(eCP_wrapper

--- a/eCP/swig/eCP.i
+++ b/eCP/swig/eCP.i
@@ -1,11 +1,12 @@
 %module eCP_wrapper
 %{
 #include "../include/eCP/index/eCP.hpp"
+#include "../src/eCP/index/shared/data_structure.hpp"
 %}
 
-%include "std_vector.i"
-%include "std_pair.i"
-%include "typemaps.i"
+%include std_vector.i
+%include std_pair.i
+%include typemaps.i
 
 namespace std {
   %template(UIntVector) std::vector<unsigned int>;
@@ -14,6 +15,14 @@ namespace std {
   %template(PairVector) std::pair<std::vector<unsigned int>, std::vector<float>>;
   %template(FloatPointerVector) std::vector<float*>;
 }
+
+%include "../include/eCP/index/eCP.hpp"
+%include "../src/eCP/index/shared/data_structure.hpp"
+
+// This can line can be tried next if there still seems to be a leak
+//%typemap(newfree) Index * "free($1);";
+
+%newobject eCP::eCP_Index;
 
 namespace eCP {
   Index* eCP::eCP_Index(const std::vector<std::vector<float>> &descriptors, unsigned int L, unsigned int metric);


### PR DESCRIPTION
An attempt at a solution for the memory leaks that were experienced by @fremartini.

See comments in commits for details.

If the changes in these two commits initially doesn't cut it, try to uncomment the line in **eCP.i** in commit 1bfeb1e9f69394bb60513c6b6f2e95910bda2676, because that might have an effect.